### PR TITLE
PR #2 from RZ_edit/quickslots

### DIFF
--- a/overrides/CombatSystem/ui/hud/quiverHud.ui
+++ b/overrides/CombatSystem/ui/hud/quiverHud.ui
@@ -20,13 +20,13 @@
                 "layoutInfo": {
                     "width": 50,
                     "use-content-height": true,
-                    "position-right":{
+                    "position-right": {
                         "target": "RIGHT",
-                        "offset": 115
+                        "offset": 25
                     },
                     "position-bottom": {
                         "target": "BOTTOM",
-                        "offset": 17
+                        "offset": 35
                     }
                 }
             }

--- a/overrides/Health/ui/hud/healthHud.ui
+++ b/overrides/Health/ui/hud/healthHud.ui
@@ -18,7 +18,7 @@
           "position-horizontal-center": {},
           "position-bottom": {
             "target": "BOTTOM",
-            "offset": 10
+            "offset": 5
           }
         }
       }

--- a/overrides/Inventory/ui/hud/inventoryHud.ui
+++ b/overrides/Inventory/ui/hud/inventoryHud.ui
@@ -9,39 +9,11 @@
                 "type": "flowLayout",
                 "id": "toolbar",
                 "rightToLeftAlign": true,
-                "verticalSpacing": 10,
                 "contents": [
                     {
                         "type": "InventoryCell",
-                        "targetSlot": 9
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 8
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 7
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 6
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 5
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 4
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 3
-                    },
-                    {
-                        "type": "InventoryCell",
-                        "targetSlot": 2
+                        "targetSlot": 0,
+                        "selected": true
                     },
                     {
                         "type": "InventoryCell",
@@ -49,18 +21,47 @@
                     },
                     {
                         "type": "InventoryCell",
-                        "targetSlot": 0,
-                        "selected": true
+                        "targetSlot": 2
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 3
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 4
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 5
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 6
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 7
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 8
+                    },
+                    {
+                        "type": "InventoryCell",
+                        "targetSlot": 9
                     }
                 ],
                 "layoutInfo": {
-                    "width" : 90,
                     "use-content-height": true,
+                    "use-content-width": true,
                     "position-bottom": {
-                        "offset": 10
+                        "target": "BOTTOM",
+                        "offset": 35
                     },
                     "position-right": {
-                        "offset": 10
+                        "target": "RIGHT",
+                        "offset": 75
                     }
                 }
             },


### PR DESCRIPTION
Repositioned quiverHud.ui & healthHud.ui

inventoryHud.ui is now a horizontal quickslot bar and will wrap its contents if the window size is manually decreased

*This is a quick fix for the problem, but does not solve the issue for the original orientation of the inventory quickslot bar.